### PR TITLE
Rename "enums" to better align with methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Release History
+
+## 0.5.0 (Unreleased)
+
+### Breaking Changes
+
+- Renamed `EncryptionAlgorithm` to `EncryptAlgorithm`.
+- Renamed `SignatureAlgorithm` to `SignAlgorithm`.
+- Renamed `KeyWrapAlgorithm` to `WrapKeyAlgorithm`.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ import (
 func encryptAndDecrypt(client *azcrypto.Client, plaintext string) (string, error) {
     encryptResult, err := client.Encrypt(
         context.TODO(),
-        azcrypto.EncryptionAlgorithmRSAOAEP256,
+        azcrypto.EncryptAlgorithmRSAOAEP256,
         []byte(plaintext),
         nil,
     )
@@ -87,7 +87,7 @@ func encryptAndDecrypt(client *azcrypto.Client, plaintext string) (string, error
 
     decryptResult, err := client.Decrypt(
         context.TODO(),
-        azcrypto.EncryptionAlgorithmRSAOAEP256,
+        azcrypto.EncryptAlgorithmRSAOAEP256,
         encryptResult.Ciphertext,
         nil,
     )
@@ -117,7 +117,7 @@ func signAndVerify(client *azcrypto.Client, plaintext string) (bool, error) {
     // Performed remotely by Azure Key Vault or Managed HSM.
     signResult, err := client.SignData(
         context.TODO(),
-        azcrypto.SignatureAlgorithmES256,
+        azcrypto.SignAlgorithmES256,
         []byte(plaintext),
         nil,
     )
@@ -160,7 +160,7 @@ import (
 func wrapAndUnwrapKey(client *azcrypto.Client, key []byte) ([]byte, error) {
     wrappedKey, err := client.WrapKey(
         context.TODO(),
-        azcrypto.KeyWrapAlgorithmRSAOAEP256,
+        azcrypto.WrapKeyAlgorithmRSAOAEP256,
         key,
         nil,
     )
@@ -170,7 +170,7 @@ func wrapAndUnwrapKey(client *azcrypto.Client, key []byte) ([]byte, error) {
 
     unwrappedKey, err := client.Decrypt(
         context.TODO(),
-        azcrypto.KeyWrapAlgorithmRSAOAEP256,
+        azcrypto.WrapKeyAlgorithmRSAOAEP256,
         wrappedKey.EncryptedKey,
         nil,
     )

--- a/algorithms.go
+++ b/algorithms.go
@@ -8,64 +8,65 @@ import (
 	alg "github.com/heaths/azcrypto/internal/algorithm"
 )
 
-// EncryptionAlgorithm defines the encryption algorithms supported by Azure Key Vault or MAnaged HSM.
-type EncryptionAlgorithm = alg.EncryptionAlgorithm
+// EncryptAlgorithm defines the encryption algorithms supported by Azure Key Vault or MAnaged HSM.
+type EncryptAlgorithm = alg.EncryptAlgorithm
 
 const (
-	// EncryptionAlgorithmRSA15 uses RSA 1.5.
-	EncryptionAlgorithmRSA15 EncryptionAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSA15
+	// EncryptAlgorithmRSA15 uses RSA 1.5.
+	EncryptAlgorithmRSA15 EncryptAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSA15
 
-	// EncryptionAlgorithmRSAOAEP uses RSA-OAEP.
-	EncryptionAlgorithmRSAOAEP EncryptionAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP
+	// EncryptAlgorithmRSAOAEP uses RSA-OAEP.
+	EncryptAlgorithmRSAOAEP EncryptAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP
 
-	// EncryptionAlgorithmRSAOAEP256 uses RSA-OAEP-256.
-	EncryptionAlgorithmRSAOAEP256 EncryptionAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP256
+	// EncryptAlgorithmRSAOAEP256 uses RSA-OAEP-256.
+	EncryptAlgorithmRSAOAEP256 EncryptAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP256
 )
 
-// SignatureAlgorithm defines the signing algorithms supported by Azure Key Vault or Managed HSM.
-type SignatureAlgorithm = alg.SignatureAlgorithm
+// SignAlgorithm defines the signing algorithms supported by Azure Key Vault or Managed HSM.
+type SignAlgorithm = alg.SignAlgorithm
 
 const (
-	// SignatureAlgorithmES256 uses the P-256 curve requiring a SHA-256 hash.
-	SignatureAlgorithmES256 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES256
+	// SignAlgorithmES256 uses the P-256 curve requiring a SHA-256 hash.
+	SignAlgorithmES256 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES256
 
-	// SignatureAlgorithmES256K uses the P-256K curve requiring a SHA-256 hash.
-	SignatureAlgorithmES256K SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES256K
+	// SignAlgorithmES256K uses the P-256K curve requiring a SHA-256 hash.
+	SignAlgorithmES256K SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES256K
 
-	// SignatureAlgorithmES384 uses the P-384 curve requiring a SHA-384 hash.
-	SignatureAlgorithmES384 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES384
+	// SignAlgorithmES384 uses the P-384 curve requiring a SHA-384 hash.
+	SignAlgorithmES384 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES384
 
-	// SignatureAlgorithmES512 uses the P-521 curve requiring a SHA-512 hash.
-	SignatureAlgorithmES512 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES512
+	// SignAlgorithmES512 uses the P-521 curve requiring a SHA-512 hash.
+	SignAlgorithmES512 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmES512
 
-	// SignatureAlgorithmPS256 uses RSASSA-PSS using a SHA-256 hash.
-	SignatureAlgorithmPS256 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmPS256
+	// SignAlgorithmPS256 uses RSASSA-PSS using a SHA-256 hash.
+	SignAlgorithmPS256 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmPS256
 
-	// SignatureAlgorithmPS384 uses RSASSA-PSS using a SHA-384 hash.
-	SignatureAlgorithmPS384 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmPS384
+	// SignAlgorithmPS384 uses RSASSA-PSS using a SHA-384 hash.
+	SignAlgorithmPS384 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmPS384
 
-	// SignatureAlgorithmPS512 uses RSASSA-PSS using a SHA-512 hash.
-	SignatureAlgorithmPS512 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmPS512
+	// SignAlgorithmPS512 uses RSASSA-PSS using a SHA-512 hash.
+	SignAlgorithmPS512 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmPS512
 
-	// SignatureAlgorithmRS256 uses RSASSA-PKCS1-v1_5 using a SHA256 hash.
-	SignatureAlgorithmRS256 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmRS256
+	// SignAlgorithmRS256 uses RSASSA-PKCS1-v1_5 using a SHA256 hash.
+	SignAlgorithmRS256 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmRS256
 
-	// SignatureAlgorithmRS384 uses RSASSA-PKCS1-v1_5 using a SHA384 hash.
-	SignatureAlgorithmRS384 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmRS384
+	// SignAlgorithmRS384 uses RSASSA-PKCS1-v1_5 using a SHA384 hash.
+	SignAlgorithmRS384 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmRS384
 
-	// SignatureAlgorithmRS512 uses RSASSA-PKCS1-v1_5 using a SHA512 hash.
-	SignatureAlgorithmRS512 SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithmRS512
+	// SignAlgorithmRS512 uses RSASSA-PKCS1-v1_5 using a SHA512 hash.
+	SignAlgorithmRS512 SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithmRS512
 )
 
-type KeyWrapAlgorithm = alg.KeyWrapAlgorithm
+// WrapKeyAlgorithm defines the key wrap algorithms supported by Azure Key Vault or Managed HSM.
+type WrapKeyAlgorithm = alg.WrapKeyAlgorithm
 
 const (
-	// KeyWrapAlgorithmRSA15 uses RSA 1.5.
-	KeyWrapAlgorithmRSA15 KeyWrapAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSA15
+	// WrapKeyAlgorithmRSA15 uses RSA 1.5.
+	WrapKeyAlgorithmRSA15 WrapKeyAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSA15
 
-	// KeyWrapAlgorithmRSAOAEP uses RSA-OAEP.
-	KeyWrapAlgorithmRSAOAEP KeyWrapAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP
+	// WrapKeyAlgorithmRSAOAEP uses RSA-OAEP.
+	WrapKeyAlgorithmRSAOAEP WrapKeyAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP
 
-	// KeyWrapAlgorithmRSAOAEP256 uses RSA-OAEP-256.
-	KeyWrapAlgorithmRSAOAEP256 KeyWrapAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP256
+	// WrapKeyAlgorithmRSAOAEP256 uses RSA-OAEP-256.
+	WrapKeyAlgorithmRSAOAEP256 WrapKeyAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithmRSAOAEP256
 )

--- a/client.go
+++ b/client.go
@@ -111,7 +111,7 @@ type EncryptOptions struct {
 type EncryptResult = alg.EncryptResult
 
 // Encrypt encrypts the plaintext using the specified algorithm.
-func (client *Client) Encrypt(ctx context.Context, algorithm EncryptionAlgorithm, plaintext []byte, options *EncryptOptions) (EncryptResult, error) {
+func (client *Client) Encrypt(ctx context.Context, algorithm EncryptAlgorithm, plaintext []byte, options *EncryptOptions) (EncryptResult, error) {
 	client.init(ctx)
 
 	if client.localClient != nil {
@@ -164,7 +164,7 @@ type DecryptOptions struct {
 type DecryptResult = alg.DecryptResult
 
 // Decrypt decrypts the ciphertext using the specified algorithm.
-func (client *Client) Decrypt(ctx context.Context, algorithm EncryptionAlgorithm, ciphertext []byte, options *DecryptOptions) (DecryptResult, error) {
+func (client *Client) Decrypt(ctx context.Context, algorithm EncryptAlgorithm, ciphertext []byte, options *DecryptOptions) (DecryptResult, error) {
 	// Decrypting requires access to a private key, which Key Vault does not provide by default.
 	parameters := azkeys.KeyOperationsParameters{
 		Algorithm: &algorithm,
@@ -209,7 +209,7 @@ type SignOptions struct {
 type SignResult = alg.SignResult
 
 // Sign signs the specified digest using the specified algorithm.
-func (client *Client) Sign(ctx context.Context, algorithm SignatureAlgorithm, digest []byte, options *SignOptions) (SignResult, error) {
+func (client *Client) Sign(ctx context.Context, algorithm SignAlgorithm, digest []byte, options *SignOptions) (SignResult, error) {
 	// Signing requires access to a private key, which Key Vault does not provide by default.
 	parameters := azkeys.SignParameters{
 		Algorithm: &algorithm,
@@ -251,7 +251,7 @@ type SignDataOptions struct {
 }
 
 // SignData hashes the data using a suitable hash based on the specified algorithm.
-func (client *Client) SignData(ctx context.Context, algorithm SignatureAlgorithm, data []byte, options *SignDataOptions) (SignResult, error) {
+func (client *Client) SignData(ctx context.Context, algorithm SignAlgorithm, data []byte, options *SignDataOptions) (SignResult, error) {
 	hash, err := alg.GetHash(algorithm)
 	if err != nil {
 		return SignResult{}, err
@@ -277,7 +277,7 @@ type VerifyOptions struct {
 type VerifyResult = alg.VerifyResult
 
 // Verify verifies that the specified digest is valid using the specified signature and algorithm.
-func (client *Client) Verify(ctx context.Context, algorithm SignatureAlgorithm, digest, signature []byte, options *VerifyOptions) (VerifyResult, error) {
+func (client *Client) Verify(ctx context.Context, algorithm SignAlgorithm, digest, signature []byte, options *VerifyOptions) (VerifyResult, error) {
 	client.init(ctx)
 
 	if client.localClient != nil {
@@ -323,7 +323,7 @@ type VerifyDataOptions struct {
 }
 
 // VerifyData verifies the digest of the data is valid using a suitable hash based on the specified algorithm.
-func (client *Client) VerifyData(ctx context.Context, algorithm SignatureAlgorithm, data, signature []byte, options *VerifyDataOptions) (VerifyResult, error) {
+func (client *Client) VerifyData(ctx context.Context, algorithm SignAlgorithm, data, signature []byte, options *VerifyDataOptions) (VerifyResult, error) {
 	hash, err := alg.GetHash(algorithm)
 	if err != nil {
 		return VerifyResult{}, err
@@ -349,7 +349,7 @@ type WrapKeyOptions struct {
 type WrapKeyResult = alg.WrapKeyResult
 
 // WrapKey encrypts the specified key using the specified algorithm. Asymmetric encryption is typically used to wrap a symmetric key used for streaming ciphers.
-func (client *Client) WrapKey(ctx context.Context, algorithm KeyWrapAlgorithm, key []byte, options *WrapKeyOptions) (WrapKeyResult, error) {
+func (client *Client) WrapKey(ctx context.Context, algorithm WrapKeyAlgorithm, key []byte, options *WrapKeyOptions) (WrapKeyResult, error) {
 	client.init(ctx)
 
 	if client.localClient != nil {
@@ -402,7 +402,7 @@ type UnwrapKeyOptions struct {
 type UnwrapKeyResult = alg.UnwrapKeyResult
 
 // UnwrapKey decrypts the specified key using the specified algorithm. Asymmetric decryption is typically used to unwrap a symmetric key used for streaming ciphers.
-func (client *Client) UnwrapKey(ctx context.Context, algorithm KeyWrapAlgorithm, encryptedKey []byte, options *UnwrapKeyOptions) (UnwrapKeyResult, error) {
+func (client *Client) UnwrapKey(ctx context.Context, algorithm WrapKeyAlgorithm, encryptedKey []byte, options *UnwrapKeyOptions) (UnwrapKeyResult, error) {
 	// Unwrapping a key requires access to a private key, which Key Vault does not provide by default.
 	parameters := azkeys.KeyOperationsParameters{
 		Algorithm: &algorithm,

--- a/client_test.go
+++ b/client_test.go
@@ -45,47 +45,47 @@ func TestClient_EncryptDecrypt(t *testing.T) {
 	tests := []struct {
 		name       string
 		key        string
-		alg        EncryptionAlgorithm
+		alg        EncryptAlgorithm
 		permission bool
 		err        error
 	}{
 		{
 			name:       "RSA1_5",
 			key:        "rsa2048",
-			alg:        EncryptionAlgorithmRSA15,
+			alg:        EncryptAlgorithmRSA15,
 			permission: true,
 		},
 		{
 			name: "RSA1_5 local",
 			key:  "rsa2048",
-			alg:  EncryptionAlgorithmRSA15,
+			alg:  EncryptAlgorithmRSA15,
 		},
 		{
 			name:       "RSA-OAEP",
 			key:        "rsa2048",
-			alg:        EncryptionAlgorithmRSAOAEP,
+			alg:        EncryptAlgorithmRSAOAEP,
 			permission: true,
 		},
 		{
 			name: "RSA-OAEP local",
 			key:  "rsa2048",
-			alg:  EncryptionAlgorithmRSAOAEP,
+			alg:  EncryptAlgorithmRSAOAEP,
 		},
 		{
 			name:       "RSA-OAEP-256",
 			key:        "rsa2048",
-			alg:        EncryptionAlgorithmRSAOAEP256,
+			alg:        EncryptAlgorithmRSAOAEP256,
 			permission: true,
 		},
 		{
 			name: "RSA-OAEP-256 local",
 			key:  "rsa2048",
-			alg:  EncryptionAlgorithmRSAOAEP256,
+			alg:  EncryptAlgorithmRSAOAEP256,
 		},
 		{
 			name: "missing",
 			key:  "missing",
-			alg:  EncryptionAlgorithmRSAOAEP,
+			alg:  EncryptAlgorithmRSAOAEP,
 			err: &azcore.ResponseError{
 				StatusCode: 404,
 			},
@@ -124,7 +124,7 @@ func TestClient_SignVerify(t *testing.T) {
 	type testData struct {
 		name       string
 		key        string
-		alg        SignatureAlgorithm
+		alg        SignAlgorithm
 		permission bool
 		err        error
 	}
@@ -132,7 +132,7 @@ func TestClient_SignVerify(t *testing.T) {
 		{
 			name: "missing",
 			key:  "missing",
-			alg:  SignatureAlgorithmES256,
+			alg:  SignAlgorithmES256,
 			err: &azcore.ResponseError{
 				StatusCode: 404,
 			},
@@ -142,13 +142,13 @@ func TestClient_SignVerify(t *testing.T) {
 	keys := []struct {
 		name string
 		key  string
-		alg  SignatureAlgorithm
+		alg  SignAlgorithm
 	}{
-		{name: "ES256", key: "ec256", alg: SignatureAlgorithmES256},
-		{name: "ES384", key: "ec384", alg: SignatureAlgorithmES384},
-		{name: "ES512", key: "ec521", alg: SignatureAlgorithmES512},
-		{name: "PS256", key: "rsa2048", alg: SignatureAlgorithmPS256},
-		{name: "RS512", key: "rsa2048", alg: SignatureAlgorithmRS512},
+		{name: "ES256", key: "ec256", alg: SignAlgorithmES256},
+		{name: "ES384", key: "ec384", alg: SignAlgorithmES384},
+		{name: "ES512", key: "ec521", alg: SignAlgorithmES512},
+		{name: "PS256", key: "rsa2048", alg: SignAlgorithmPS256},
+		{name: "RS512", key: "rsa2048", alg: SignAlgorithmRS512},
 	}
 
 	for _, key := range keys {
@@ -197,47 +197,47 @@ func TestClient_WrapUnwrapKey(t *testing.T) {
 	tests := []struct {
 		name       string
 		key        string
-		alg        KeyWrapAlgorithm
+		alg        WrapKeyAlgorithm
 		permission bool
 		err        error
 	}{
 		{
 			name:       "RSA1_5",
 			key:        "rsa2048",
-			alg:        KeyWrapAlgorithmRSA15,
+			alg:        WrapKeyAlgorithmRSA15,
 			permission: true,
 		},
 		{
 			name: "RSA1_5 local",
 			key:  "rsa2048",
-			alg:  KeyWrapAlgorithmRSA15,
+			alg:  WrapKeyAlgorithmRSA15,
 		},
 		{
 			name:       "RSA-OAEP",
 			key:        "rsa2048",
-			alg:        KeyWrapAlgorithmRSAOAEP,
+			alg:        WrapKeyAlgorithmRSAOAEP,
 			permission: true,
 		},
 		{
 			name: "RSA-OAEP local",
 			key:  "rsa2048",
-			alg:  EncryptionAlgorithmRSAOAEP,
+			alg:  WrapKeyAlgorithmRSAOAEP,
 		},
 		{
 			name:       "RSA-OAEP-256",
 			key:        "rsa2048",
-			alg:        KeyWrapAlgorithmRSAOAEP256,
+			alg:        WrapKeyAlgorithmRSAOAEP256,
 			permission: true,
 		},
 		{
 			name: "RSA-OAEP-256 local",
 			key:  "rsa2048",
-			alg:  KeyWrapAlgorithmRSAOAEP256,
+			alg:  WrapKeyAlgorithmRSAOAEP256,
 		},
 		{
 			name: "missing",
 			key:  "missing",
-			alg:  KeyWrapAlgorithmRSAOAEP,
+			alg:  WrapKeyAlgorithmRSAOAEP,
 			err: &azcore.ResponseError{
 				StatusCode: 404,
 			},

--- a/example_test.go
+++ b/example_test.go
@@ -32,7 +32,7 @@ func ExampleNewClient() {
 }
 
 func ExampleClient_Encrypt() {
-	result, err := client.Encrypt(context.TODO(), azcrypto.EncryptionAlgorithmRSAOAEP256, []byte("plaintext"), nil)
+	result, err := client.Encrypt(context.TODO(), azcrypto.EncryptAlgorithmRSAOAEP256, []byte("plaintext"), nil)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -47,7 +47,7 @@ func ExampleClient_Decrypt() {
 		// TODO: handle error
 	}
 
-	result, err := client.Decrypt(context.TODO(), azcrypto.EncryptionAlgorithmRSAOAEP256, ciphertext, nil)
+	result, err := client.Decrypt(context.TODO(), azcrypto.EncryptAlgorithmRSAOAEP256, ciphertext, nil)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -60,7 +60,7 @@ func ExampleClient_Sign() {
 	hash.Write([]byte("plaintext"))
 	digest := hash.Sum(nil)
 
-	result, err := client.Sign(context.TODO(), azcrypto.SignatureAlgorithmES256, digest, nil)
+	result, err := client.Sign(context.TODO(), azcrypto.SignAlgorithmES256, digest, nil)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -69,7 +69,7 @@ func ExampleClient_Sign() {
 }
 
 func ExampleClient_SignData() {
-	result, err := client.SignData(context.TODO(), azcrypto.SignatureAlgorithmES256, []byte("plaintext"), nil)
+	result, err := client.SignData(context.TODO(), azcrypto.SignAlgorithmES256, []byte("plaintext"), nil)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -86,7 +86,7 @@ func ExampleClient_WrapKey() {
 	}
 
 	// Encrypt the key using RSA-OAEP-256 to be stored securely.
-	result, err := client.WrapKey(context.TODO(), azcrypto.KeyWrapAlgorithmRSAOAEP256, key, nil)
+	result, err := client.WrapKey(context.TODO(), azcrypto.WrapKeyAlgorithmRSAOAEP256, key, nil)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -102,7 +102,7 @@ func ExampleClient_UnwrapKey() {
 	}
 
 	// Decrypt the key for use as a block cipher for e.g., streaming data.
-	result, err := client.UnwrapKey(context.TODO(), azcrypto.KeyWrapAlgorithmRSAOAEP256, encryptedKey, nil)
+	result, err := client.UnwrapKey(context.TODO(), azcrypto.WrapKeyAlgorithmRSAOAEP256, encryptedKey, nil)
 	if err != nil {
 		// TODO: handle error
 	}
@@ -117,7 +117,7 @@ func ExampleClient_Verify() {
 		// TODO: handle error
 	}
 
-	result, err := client.VerifyData(context.TODO(), azcrypto.SignatureAlgorithmES256, []byte("plaintext"), signature, nil)
+	result, err := client.VerifyData(context.TODO(), azcrypto.SignAlgorithmES256, []byte("plaintext"), signature, nil)
 	if err != nil {
 		// TODO: handle error
 	}

--- a/internal/algorithm/algorithm.go
+++ b/internal/algorithm/algorithm.go
@@ -13,14 +13,14 @@ import (
 	_ "github.com/heaths/azcrypto/internal/test"
 )
 
-type EncryptionAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithm
-type SignatureAlgorithm = azkeys.JSONWebKeySignatureAlgorithm
-type KeyWrapAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithm
+type EncryptAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithm
+type SignAlgorithm = azkeys.JSONWebKeySignatureAlgorithm
+type WrapKeyAlgorithm = azkeys.JSONWebKeyEncryptionAlgorithm
 
 type Algorithm interface {
-	Encrypt(algorithm EncryptionAlgorithm, plaintext []byte) (EncryptResult, error)
-	Verify(algorithm SignatureAlgorithm, digest, signature []byte) (VerifyResult, error)
-	WrapKey(algorithm KeyWrapAlgorithm, key []byte) (WrapKeyResult, error)
+	Encrypt(algorithm EncryptAlgorithm, plaintext []byte) (EncryptResult, error)
+	Verify(algorithm SignAlgorithm, digest, signature []byte) (VerifyResult, error)
+	WrapKey(algorithm WrapKeyAlgorithm, key []byte) (WrapKeyResult, error)
 }
 
 func NewAlgorithm(key azkeys.JSONWebKey) (Algorithm, error) {
@@ -46,7 +46,7 @@ func NewAlgorithm(key azkeys.JSONWebKey) (Algorithm, error) {
 	}
 }
 
-func GetHash(algorithm SignatureAlgorithm) (crypto.Hash, error) {
+func GetHash(algorithm SignAlgorithm) (crypto.Hash, error) {
 	switch algorithm {
 	case azkeys.JSONWebKeySignatureAlgorithmPS256:
 		fallthrough
@@ -78,7 +78,7 @@ func GetHash(algorithm SignatureAlgorithm) (crypto.Hash, error) {
 
 type EncryptResult struct {
 	// Algorithm is encryption algorithm used to encrypt.
-	Algorithm EncryptionAlgorithm
+	Algorithm EncryptAlgorithm
 
 	// KeyID is the key ID used to encrypt. This key ID should be retained.
 	KeyID string
@@ -89,7 +89,7 @@ type EncryptResult struct {
 
 type DecryptResult struct {
 	// Algorithm is encryption algorithm used to decrypt.
-	Algorithm EncryptionAlgorithm
+	Algorithm EncryptAlgorithm
 
 	// KeyID is the key ID used to decrypt.
 	KeyID string
@@ -100,7 +100,7 @@ type DecryptResult struct {
 
 type SignResult struct {
 	// Algorithm is the signature algorithm used to sign.
-	Algorithm SignatureAlgorithm
+	Algorithm SignAlgorithm
 
 	// KeyID is the key ID used to sign. This key ID should be retained.
 	KeyID string
@@ -111,7 +111,7 @@ type SignResult struct {
 
 type VerifyResult struct {
 	// Algorithm is the signature algorithm used to verify.
-	Algorithm SignatureAlgorithm
+	Algorithm SignAlgorithm
 
 	// KeyID is the key ID used to verify.
 	KeyID string
@@ -122,7 +122,7 @@ type VerifyResult struct {
 
 type WrapKeyResult struct {
 	// Algorithm is the key wrap algorithm used to wrap.
-	Algorithm KeyWrapAlgorithm
+	Algorithm WrapKeyAlgorithm
 
 	// KeyID is the key ID used to wrap. This key ID should be retained.
 	KeyID string
@@ -133,7 +133,7 @@ type WrapKeyResult struct {
 
 type UnwrapKeyResult struct {
 	// Algorithm is the key wrap algorithm used to unwrap.
-	Algorithm KeyWrapAlgorithm
+	Algorithm WrapKeyAlgorithm
 
 	// KeyID is the key ID used to unwrap.
 	KeyID string

--- a/internal/algorithm/algorithm_test.go
+++ b/internal/algorithm/algorithm_test.go
@@ -95,7 +95,7 @@ func TestGetHash(t *testing.T) {
 
 	tests := []struct {
 		name string
-		alg  SignatureAlgorithm
+		alg  SignAlgorithm
 		h    crypto.Hash
 		err  error
 	}{

--- a/internal/algorithm/ecdsa.go
+++ b/internal/algorithm/ecdsa.go
@@ -61,11 +61,11 @@ func fromCurve(crv azkeys.JSONWebKeyCurveName) (elliptic.Curve, error) {
 	}
 }
 
-func (c ECDsa) Encrypt(algorithm EncryptionAlgorithm, plaintext []byte) (EncryptResult, error) {
+func (c ECDsa) Encrypt(algorithm EncryptAlgorithm, plaintext []byte) (EncryptResult, error) {
 	return EncryptResult{}, internal.ErrUnsupported
 }
 
-func (c ECDsa) Verify(algorithm SignatureAlgorithm, digest, signature []byte) (VerifyResult, error) {
+func (c ECDsa) Verify(algorithm SignAlgorithm, digest, signature []byte) (VerifyResult, error) {
 	// Key Vault and Managed HSM concatenate r and s components.
 	r := new(big.Int).SetBytes(signature[:len(signature)/2])
 	s := new(big.Int).SetBytes(signature[len(signature)/2:])
@@ -77,6 +77,6 @@ func (c ECDsa) Verify(algorithm SignatureAlgorithm, digest, signature []byte) (V
 	}, nil
 }
 
-func (c ECDsa) WrapKey(algorithm KeyWrapAlgorithm, key []byte) (WrapKeyResult, error) {
+func (c ECDsa) WrapKey(algorithm WrapKeyAlgorithm, key []byte) (WrapKeyResult, error) {
 	return WrapKeyResult{}, internal.ErrUnsupported
 }

--- a/internal/algorithm/rsa.go
+++ b/internal/algorithm/rsa.go
@@ -42,7 +42,7 @@ func newRSA(key azkeys.JSONWebKey) (RSA, error) {
 	}, nil
 }
 
-func (r RSA) Encrypt(algorithm EncryptionAlgorithm, plaintext []byte) (EncryptResult, error) {
+func (r RSA) Encrypt(algorithm EncryptAlgorithm, plaintext []byte) (EncryptResult, error) {
 	var ciphertext []byte
 	var err error
 
@@ -55,7 +55,7 @@ func (r RSA) Encrypt(algorithm EncryptionAlgorithm, plaintext []byte) (EncryptRe
 			return crypto.SHA256
 
 		default:
-			panic("unexpected EncryptionAlgorithm")
+			panic("unexpected EncryptAlgorithm")
 		}
 	}
 
@@ -81,7 +81,7 @@ func (r RSA) Encrypt(algorithm EncryptionAlgorithm, plaintext []byte) (EncryptRe
 	}, nil
 }
 
-func (r RSA) Verify(algorithm SignatureAlgorithm, digest, signature []byte) (VerifyResult, error) {
+func (r RSA) Verify(algorithm SignAlgorithm, digest, signature []byte) (VerifyResult, error) {
 	hash, err := GetHash(algorithm)
 	if err != nil {
 		return VerifyResult{}, err
@@ -103,7 +103,7 @@ func (r RSA) Verify(algorithm SignatureAlgorithm, digest, signature []byte) (Ver
 		err = rsa.VerifyPKCS1v15(&r.pub, hash, digest, signature)
 
 	default:
-		panic("unexpected SignatureAlgorithm")
+		panic("unexpected SignAlgorithm")
 	}
 
 	return VerifyResult{
@@ -113,7 +113,7 @@ func (r RSA) Verify(algorithm SignatureAlgorithm, digest, signature []byte) (Ver
 	}, nil
 }
 
-func (r RSA) WrapKey(algorithm KeyWrapAlgorithm, key []byte) (WrapKeyResult, error) {
+func (r RSA) WrapKey(algorithm WrapKeyAlgorithm, key []byte) (WrapKeyResult, error) {
 	var encryptedKey []byte
 	var err error
 
@@ -126,7 +126,7 @@ func (r RSA) WrapKey(algorithm KeyWrapAlgorithm, key []byte) (WrapKeyResult, err
 			return crypto.SHA256
 
 		default:
-			panic("unexpected KeyWrapAlgorithm")
+			panic("unexpected WrapKeyAlgorithm")
 		}
 	}
 


### PR DESCRIPTION
Will be adding Managed HSM-specific method "overloads" for AES, so this is preparatory work I want to keep separate in case we want to more easily revert it later. This does break from naming of other languages' similar enums.
