### PR TITLE
Assert algorithm interfaces

### DIFF
--- a/internal/algorithm/aes_test.go
+++ b/internal/algorithm/aes_test.go
@@ -80,6 +80,12 @@ func TestNewAES(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.keyID, alg.keyID)
 			require.Equal(t, tt.blockSize, alg.block.BlockSize())
+
+			var encrypter AESEncrypter
+			require.Implements(t, &encrypter, alg)
+
+			var wrapper KeyWrapper
+			require.Implements(t, &wrapper, alg)
 		})
 	}
 }

--- a/internal/algorithm/ecdsa_test.go
+++ b/internal/algorithm/ecdsa_test.go
@@ -101,6 +101,9 @@ func TestNewECDsa(t *testing.T) {
 			if len(tt.key.D) > 0 {
 				require.NotNil(t, alg.key.D)
 			}
+
+			var signer Signer
+			require.Implements(t, &signer, alg)
 		})
 	}
 }

--- a/internal/algorithm/rsa_test.go
+++ b/internal/algorithm/rsa_test.go
@@ -53,6 +53,12 @@ func TestNewRSA(t *testing.T) {
 			}
 			require.NoError(t, err)
 			require.Equal(t, tt.keyID, alg.keyID)
+
+			var encrypter Encrypter
+			require.Implements(t, &encrypter, alg)
+
+			var wrapper KeyWrapper
+			require.Implements(t, &wrapper, alg)
 		})
 	}
 }


### PR DESCRIPTION
Errors in client_test.go can be unintuitive if the interface isn't fully implemented given how we're checking, so assert the implementation in algorithm-specific test cases.
